### PR TITLE
Adding link to Codesandbox.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ JavaScript modules and partials are new building blocks you can use to write Rea
 
 ## Building Block Examples
 
-In this repository is example usage of some of key features of JS Building Blocks. These examples are are best understood alongside our official [documentation](docs).
+In this repository is example usage of some of key features of JS Building Blocks. These examples are are best understood alongside our official [documentation](docs). You can quickly get started without any local setup by [opening this repo in Codesandbox.io](https://codesandbox.io/p/sandbox/stoic-pateu-g20chg?file=%2Fcms-js-building-block-examples%2FREADME.md).
+
+<img width="400" alt="Preview of examples in Codesandbox.io interface" src="https://github.com/HubSpot/cms-js-building-block-examples/assets/60455/e8ab456e-39a6-4919-b256-584cd7054cb2">
+
+<br>
 
 ### [Styling](styling)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ JavaScript modules and partials are new building blocks you can use to write Rea
 
 ## Building Block Examples
 
-In this repository is example usage of some of key features of JS Building Blocks. These examples are are best understood alongside our official [documentation](docs). You can quickly get started without any local setup by [opening this repo in Codesandbox.io](https://codesandbox.io/p/sandbox/stoic-pateu-g20chg?file=%2Fcms-js-building-block-examples%2FREADME.md).
+In this repository is example usage of some of key features of JS Building Blocks. These examples are are best understood alongside our official [documentation](docs). You can quickly try things out without any local setup by [opening this repo in Codesandbox.io](https://codesandbox.io/p/sandbox/stoic-pateu-g20chg?file=%2Fcms-js-building-block-examples%2FREADME.md).
 
 <img width="400" alt="Preview of examples in Codesandbox.io interface" src="https://github.com/HubSpot/cms-js-building-block-examples/assets/60455/e8ab456e-39a6-4919-b256-584cd7054cb2">
 


### PR DESCRIPTION
The direct link: https://codesandbox.io/p/sandbox/stoic-pateu-g20chg?file=%2Fcms-js-building-block-examples%2FREADME.md

... and little picture: 

<img width=400 src=https://github.com/HubSpot/cms-js-building-block-examples/assets/60455/6767fbeb-7642-4bc6-bd9b-0087d8ad21db>

I believe this link will "just work" for anyone and it will prompt you to sign in once you try to make an edit. Though after you sign in, I'm pretty sure you should be able to pick up right where you left off with out having to wait for a npm install, etc.

ps: I customized this sandbox a fair bit, trying to make things install faster, etc. Also I started to make it so that all the examples could run concurrently, but we need to enable customizing HMR ports for that to work (since they still overlap even though I set different ports for each example in the tasks.json)