### PR TITLE
Add some "important" tailwind config to make tailwind classes have higher precedence

### DIFF
--- a/styling/styling-project/styling-app/components/partials/TailwindPartial.jsx
+++ b/styling/styling-project/styling-app/components/partials/TailwindPartial.jsx
@@ -25,7 +25,8 @@ const aiArt = [
 
 export default function Example() {
   return (
-    <>
+    // Use .tailwind-wrapper config to give the tailwind classes more precedence
+    <div className="tailwind-wrapper">
       <ul className="divide-y divide-gray-200">
         {aiArt.map((art) => (
           <li key={art.name} className="py-4 flex">
@@ -49,6 +50,6 @@ export default function Example() {
           <BookOpenIcon width={200} />
         </dd>
       </dl>
-    </>
+    </div>
   );
 }

--- a/styling/styling-project/styling-app/tailwind.config.js
+++ b/styling/styling-project/styling-app/tailwind.config.js
@@ -6,4 +6,5 @@ export default {
     extend: {},
   },
   plugins: [],
+  important: '.tailwind-wrapper',
 };


### PR DESCRIPTION
Example of it working in practice after a build: 

<img width="1840" alt="image" src="https://github.com/HubSpot/cms-js-building-block-examples/assets/60455/1430b651-f072-470c-ae1c-6b5a6093a058">
