### PR TITLE
vitepress base and link from old file location

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -5,6 +5,7 @@ import fieldTypesSidebar from '../field-types/typedoc-sidebar.json';
 export default defineConfig({
   title: 'HubSpot - JS Building Blocks',
   description: 'Documentation for HubSpot CMS JS Building Blocks',
+  base: '/cms-js-building-block-examples/',
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     nav: [

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,3 @@
+# Documentation moved
+
+Documentation is now available at https://github.hubspot.com/cms-js-building-block-examples/


### PR DESCRIPTION
fix assets / links with a `base` value ([docs](https://vitepress.dev/guide/deploy#setting-a-public-base-path)) and link to the new URL from the old markdown file location