### PR TITLE
accidentally kept ^ specifier when locking in vitepress version

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -10,7 +10,10 @@ export default defineConfig({
     // https://vitepress.dev/reference/default-theme-config
     nav: [
       { text: 'Home', link: '/' },
-      { text: 'Getting Started', link: '/getting-started' },
+      {
+        text: 'Getting Started',
+        link: 'https://github.com/HubSpot/cms-js-building-block-examples/tree/main/hello-world',
+      },
       { text: 'API Reference', link: '/reference/project-structure' },
       { text: 'Appendix', link: '/appendix' },
     ],

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,6 +10,6 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "vitepress": "^1.0.0-rc.11"
+    "vitepress": "1.0.0-rc.11"
   }
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -535,7 +535,7 @@ rollup@^3.27.1:
   optionalDependencies:
     fsevents "~2.3.2"
 
-shiki@^0.14.4:
+shiki@^0.14.3:
   version "0.14.4"
   resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.14.4.tgz#2454969b466a5f75067d0f2fa0d7426d32881b20"
   integrity sha512-IXCRip2IQzKwxArNNq1S+On4KPML3Yyn8Zzs/xRgcgOWIr8ntIK3IKzjFPfjy/7kt9ZMjc+FItfqHRBg8b6tNQ==
@@ -566,10 +566,10 @@ vite@^4.4.9:
   optionalDependencies:
     fsevents "~2.3.2"
 
-vitepress@^1.0.0-rc.11:
-  version "1.0.0-rc.12"
-  resolved "https://registry.yarnpkg.com/vitepress/-/vitepress-1.0.0-rc.12.tgz#474fbbc248aad02cf27246badc266dd0ebadc3e2"
-  integrity sha512-mZknN5l9lgbBjXwumwdOQQDM+gPivswFEykEQeenY0tv7eocS+bb801IpFZT3mFV6YRhSddmbutHlFgPPADjEg==
+vitepress@1.0.0-rc.11:
+  version "1.0.0-rc.11"
+  resolved "https://registry.yarnpkg.com/vitepress/-/vitepress-1.0.0-rc.11.tgz#7d70521e840271b873220d332bc55a9c128e0eb4"
+  integrity sha512-HUnfYOadqwLSahtgQxKt9/wiNHdd80BaUfQ+DIMpfq03Iv9CWX1SCBK4gxK/bMWns3Q0ArhXajQbU/fmBwYUMg==
   dependencies:
     "@docsearch/css" "^3.5.2"
     "@docsearch/js" "^3.5.2"
@@ -579,7 +579,7 @@ vitepress@^1.0.0-rc.11:
     focus-trap "^7.5.2"
     mark.js "8.11.1"
     minisearch "^6.1.0"
-    shiki "^0.14.4"
+    shiki "^0.14.3"
     vite "^4.4.9"
     vue "^3.3.4"
 


### PR DESCRIPTION
need to lock into a specific version because rc12 has a bug with sidebar interactivity