### PR TITLE
Update API Reference Link so it works in each context

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ CMS JS Building Blocks slack channel: [\#cms-js-rendering](https://hubspotdev.sl
 
 Thank you for taking the time to explore this new direction for the HubSpot CMS! As always our goal is to solve for our customers so we welcome any and all feedback. Chat away in [\#cms-js-rendering](https://hubspotdev.slack.com/archives/C04AY1H2204) with other HubSpot developers who are pushing forward with CMS JS Building Blocks.
 
-The easiest way to get started is by following the [Hello World example guide](https://github.com/HubSpot/cms-js-building-block-examples/tree/main/hello-world). Once you've acquainted yourself with JS building blocks use the [API reference](/reference/project-structure) to learn more. If you are new to JavaScript or React, please check out the “Learning links” execution in the [appendix](/appendix) below.
+The easiest way to get started is by following the [Hello World example guide](https://github.com/HubSpot/cms-js-building-block-examples/tree/main/hello-world). Once you've acquainted yourself with JS building blocks use the [API reference](https://github.hubspot.com/cms-js-building-block-examples/reference/project-structure.html) to learn more. If you are new to JavaScript or React, please check out the “Learning links” execution in the [appendix](/appendix) below.
 
 ## What are the new JS building blocks?
 


### PR DESCRIPTION
Updated API Reference Link so it works in each context. Previously it was given 404 from the link on https://github.com/HubSpot/cms-js-building-block-examples/blob/main/docs/index.md