### PR TITLE
Revert "Simplify with relative path"

### DIFF
--- a/styling/styling-project/styling-app/tailwind.config.js
+++ b/styling/styling-project/styling-app/tailwind.config.js
@@ -1,6 +1,8 @@
+import { fileURLToPath } from 'url';
+const componentsDir = fileURLToPath(new URL('./components', import.meta.url));
+
 export default {
-  relative: true,
-  content: [`./components/**/*.{js,ts,jsx,tsx}`],
+  content: [`${componentsDir}/**/*.{js,ts,jsx,tsx}`],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
This reverts commit 19b511b78b213b7ec1c71deb34e8a17dc0179078.

Due to our build pipeline where the build runs in a parent directory of the uploaded project, this breaks the `relative` resolution for either postcss configs or tailwind configs which are `path.resolve()`-ed from the working directory