### PR TITLE
Remove line on template level overrides not being supported

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,6 @@ Additionally by building on top of JavaScript and an open source framework (Reac
 Note, CMS JS Building Blocks is still in development and we are actively working on many things. Here is a list of some features that we are actively implementing but do not work in the feature yet:
 
 - More performance optimizations
-- Support for passing template-level overrides to the module tag via HubL params
 - Support for contact variable during local proxy
 - Support for importing JS Modules into JS Partials
 


### PR DESCRIPTION
Removing line on template level overrides not being supported in the docs as they appear to be supported now from testing!