### PR TITLE
Update release-log.md for 0.13.11

### DIFF
--- a/docs/release-log.md
+++ b/docs/release-log.md
@@ -1,5 +1,13 @@
 # Release Log
 
+## 2023-01-19
+
+Type: Security fix
+
+Part of: `@hubspot/cms-components@0.13.11` (and our internal build code that uses that)
+
+Make sure that more globals in inline script elements (like `__hsServerPageUrl`, `__hsSS`, etc) are escaped so that malacious input like `'alert('got you')` or `</script><script>alert('got you')</script>` are fully escaped.
+
 ## 2023-01-02
 
 Type: Bug Fix


### PR DESCRIPTION
> Type: Security fix
> 
> Part of: `@hubspot/cms-components@0.13.11` (and our internal build code that uses that)
> 
> Make sure that more globals in inline script elements (like `__hsServerPageUrl`, `__hsSS`, etc) are escaped so that malacious input like `'alert('got you')` or `</script><script>alert('got you')</script>` are fully escaped.