### PR TITLE
Adding basic local search to our documentation

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -102,5 +102,9 @@ export default defineConfig({
         link: 'https://github.com/HubSpot/cms-js-building-block-examples/',
       },
     ],
+
+    search: {
+      provider: 'local'
+    }
   },
 });


### PR DESCRIPTION
I didn't realize that Vitepress out of the box supports build/client-side search indexing. So enabling local search to try it out. 

And from a peek locally, seems not too bad:

![image](https://github.com/HubSpot/cms-js-building-block-examples/assets/60455/66c79c4a-6e07-465f-af80-621027a8f0bc)

... and the search inside shoved into a JS file is only 200-300KB.
