### PR TITLE
Rename `secretNames` to `secrets` in `cms-assets.json`

### DIFF
--- a/docs/reference/cms-components.md
+++ b/docs/reference/cms-components.md
@@ -20,7 +20,7 @@ Returns `true` for components rendered live for a deployed project and `false` w
 
 `(secretName: string) => string`
 
-Returns a value for a given secret key. The secret must be defined using `hs secrets` in the CLI and the key must be included in a `secretNames` array in your `cms-assets.json` configuration. To prevent accidentally leaking  secrets, `getSecret()` can only be called from components executed on the server and not from the browser (i.e. within an island).
+Returns a value for a given secret key. The secret must be defined using `hs secrets` in the CLI and the key must be included in a `secrets` array in your `cms-assets.json` configuration. To prevent accidentally leaking  secrets, `getSecret()` can only be called from components executed on the server and not from the browser (i.e. within an island).
 
 See the [Secrets section](./secrets) for more information on usage.
 

--- a/docs/reference/secrets.md
+++ b/docs/reference/secrets.md
@@ -2,13 +2,13 @@
 
 JS building blocks integrate with the same secrets store used by [HubSpot serverless functions](https://developers.hubspot.com/docs/cms/data/serverless-functions#secrets) to receive sensitive data.
 
-To start using secrets, store secret values using `hs secrets add` in the HubSpot CLI, then add the names of secrets used by your components to a `secretNames` array in your `cms-assets.json` config. For example:
+To start using secrets, store secret values using `hs secrets add` in the HubSpot CLI, then add the names of secrets used by your components to a `secrets` array in your `cms-assets.json` config. For example:
 
 ```json
 // cms-assets.json
 {
   "label": "My CMS project",
-  "secretNames": ["TEST_SECRET"]
+  "secrets": ["TEST_SECRET"]
 }
 ```
 


### PR DESCRIPTION
Update documentation to note the upcoming naming change of the `secretNames` property in `cms-assets.json`. The old name will continue to be supported for 3 months, and all affected projects will be notified via warnings in the build logs.